### PR TITLE
Add Swap Page for Low-Cost, Quick Exchange with Multi-Hop Support

### DIFF
--- a/src/components/CurrencyInputRow/index.tsx
+++ b/src/components/CurrencyInputRow/index.tsx
@@ -125,7 +125,7 @@ export default function CurrencyInputRow(props: Props) {
         {!hidBlance && token && (
           <div className="blance-box">
             <Font size={14} color="two" lineHeight={20}>
-              {`${t('balance')}：${unitConverter(displayBalance, 8)}`}
+              {`${t('balance')}: ${unitConverter(displayBalance, 8)}`}
             </Font>
             {showMax && (
               <div className="max-btn" onClick={maxCallback}>

--- a/src/pages/Liquidity/components/Remove.tsx
+++ b/src/pages/Liquidity/components/Remove.tsx
@@ -58,8 +58,6 @@ export default function Remove({ pairInfo }: { pairInfo: PairInfo }) {
   const [bs] = useBalances(pairAddress, undefined, rate);
   const lpBalance = bs[0];
 
-  console.log('lpBalance: ', lpBalance, pairAddress);
-
   const showLpBalance = divDecimals(lpBalance, getLPDecimals());
 
   const min = useRef<BigNumber>(divDecimals('1', getLPDecimals()));
@@ -179,7 +177,7 @@ export default function Remove({ pairInfo }: { pairInfo: PairInfo }) {
           </Col>
           <Col>
             <Font lineHeight={14} size={12} color="two">
-              {`${t('lp')}：${lpBalanceText}`}
+              {`${t('lp')}: ${lpBalanceText}`}
             </Font>
           </Col>
         </Row>

--- a/src/pages/Swap/components/SwapInputRow/index.tsx
+++ b/src/pages/Swap/components/SwapInputRow/index.tsx
@@ -144,7 +144,7 @@ export default function SwapInputRow(props: Props) {
           {!hidBlance && (
             <div className="balance-box">
               <Font size={isMobile ? 12 : 14} color="two" lineHeight={20}>
-                {`${t('balance')}：${displayBalance}`}
+                {`${t('balance')}: ${displayBalance}`}
               </Font>
               {showMax && (
                 <div className="max-btn" onClick={onMax}>

--- a/src/pages/Swap/hooks/index.tsx
+++ b/src/pages/Swap/hooks/index.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { getPairPathApi } from '../utils';
 import { TPairRoute, TPairRoutePath } from '../types';
 import { useGetPairSyncRecords } from 'graphqlServer';
+import { DEFAULT_CHAIN } from 'constants/index';
 
 export const useGetRouteList = () => {
   const getPairSyncRecords = useGetPairSyncRecords();
@@ -21,7 +22,7 @@ export const useGetRouteList = () => {
       const pairAddressList = Object.keys(routePathMap);
       const pairRecordList = await getPairSyncRecords({
         dto: {
-          chainId: 'tDVW',
+          chainId: DEFAULT_CHAIN,
           pairAddresses: pairAddressList,
         },
       });


### PR DESCRIPTION
1. Add Swap Page for Low-Cost, Quick Exchange with Multi-Hop Support. close #104 